### PR TITLE
Add scalar scope for data types page

### DIFF
--- a/documentation/modules/ROOT/pages/datatypes.adoc
+++ b/documentation/modules/ROOT/pages/datatypes.adoc
@@ -13,6 +13,10 @@ SPDX-License-Identifier: MPL-2.0
 [[data-types]]
 = Data Types
 
+This page details *scalar* data types. Such a scalar data type gets used by a Characteristic to further define a Property. 
+
+For modeling Properties that require non-scalar data types, use xref:entities.adoc[Entities].
+
 == Type Hierarchy
 
 The system of types used in the {meta-model-full-name} (and subsequently in the models conforming to


### PR DESCRIPTION
## Description

The data types page as of now does not state that it is only about scalar data types that get used by Characteristics. 
This pull request adds the missing information and points to the Entities page for modeling Properties with non-scalar data types.

This is a quick fix (no related GitHub issue).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
